### PR TITLE
proxy expects a hostname, not a URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ granted to a task.
     -h --help                  Show this help screen.
     -p --port <port>           Port to bind the proxy server to [default: 8080].
     --relengapi-token <token>  RelengAPI token with which to reate temp tokens [default:].
-	--relengapi-url <url>  	   RelengAPI URL [default: https://api.pub.build.mozilla.org].
+	--relengapi-host <url> 	   RelengAPI hostname [default: api.pub.build.mozilla.org].
 `
 
 func main() {
@@ -46,7 +46,7 @@ func main() {
 		log.Fatal("--relengapi-token is required")
 	}
 
-	relengapiUrl := arguments["--relengapi-url"].(string)
+	relengapiHost := arguments["--relengapi-host"].(string)
 
 	scopes, err := getTaskScopes(taskId)
 	if err != nil {
@@ -60,9 +60,9 @@ func main() {
 	}
 
 	RelengapiProxy{
-		listenPort:   port,
-		relengapiUrl: relengapiUrl,
-		permissions:  relengapiPerms,
-		issuingToken: relengapiToken,
+		listenPort:    port,
+		relengapiHost: relengapiHost,
+		permissions:   relengapiPerms,
+		issuingToken:  relengapiToken,
 	}.runForever()
 }

--- a/proxy.go
+++ b/proxy.go
@@ -9,9 +9,9 @@ import (
 )
 
 type RelengapiProxy struct {
-	listenPort   int
-	relengapiUrl string
-	permissions  []string
+	listenPort    int
+	relengapiHost string
+	permissions   []string
 
 	// token used to issue temporary tokens
 	issuingToken string
@@ -35,7 +35,7 @@ func (rp *RelengapiProxy) getToken() (string, error) {
 		expires := now.Add(tmpTokenLifetime)
 		log.Printf("Generating new temporary token; expires at %v", expires)
 		tok, err := getTmpToken(
-			rp.relengapiUrl, rp.issuingToken, expires, rp.permissions)
+			rp.relengapiHost, rp.issuingToken, expires, rp.permissions)
 		if err != nil {
 			return "", err
 		}
@@ -54,8 +54,8 @@ func (rp RelengapiProxy) runForever() {
 	director := func(req *http.Request) {
 		// point toward the upstream server
 		req.URL.Scheme = "https"
-		req.URL.Host = rp.relengapiUrl
-		req.Host = rp.relengapiUrl
+		req.URL.Host = rp.relengapiHost
+		req.Host = rp.relengapiHost
 		// Add the token
 		tok, err := rp.getToken()
 		if err != nil {

--- a/relengapi.go
+++ b/relengapi.go
@@ -41,7 +41,7 @@ type relengapiTokenJson struct {
 	Token       string      `json:"token,omitempty"`
 }
 
-func getTmpToken(url string, issuingToken string, expires time.Time, perms []string) (tok string, err error) {
+func getTmpToken(hostname string, issuingToken string, expires time.Time, perms []string) (tok string, err error) {
 	// TODO: retry this operation
 	request := relengapiTokenJson{
 		Typ:         "tmp",
@@ -56,7 +56,7 @@ func getTmpToken(url string, issuingToken string, expires time.Time, perms []str
 	}
 
 	client := &http.Client{}
-	reqUrl := fmt.Sprintf("%s/tokenauth/tokens", url)
+	reqUrl := fmt.Sprintf("https://%s/tokenauth/tokens", hostname)
 	req, err := http.NewRequest("POST", reqUrl, bytes.NewBuffer(reqbody))
 	if err != nil {
 		return


### PR DESCRIPTION
The proxy doesn't do any path munging -- it just switches on https and
replaces the hostname in the URL.
