### PR TITLE
Bug 1218367 - support taskIds starting with `-` character

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,34 +19,51 @@ generated via an HTTP request to RelengAPI using the permanent token given via
 granted to a task.
 
   Usage:
-    ./proxy [options] <taskId>
-    ./proxy --help
+    ./proxy [options] -- <taskId>
+    ./proxy -h|--help
+    ./proxy --version
 
   Options:
     -h --help                  Show this help screen.
+    --version                  Show version.
     -p --port <port>           Port to bind the proxy server to [default: 8080].
-    --relengapi-token <token>  RelengAPI token with which to reate temp tokens [default:].
-	--relengapi-host <url> 	   RelengAPI hostname [default: api.pub.build.mozilla.org].
+    --relengapi-token <token>  RelengAPI token with which to create temp tokens [default:].
+    --relengapi-host <url>     RelengAPI hostname [default: api.pub.build.mozilla.org].
 `
 
 func main() {
+
 	arguments, err := docopt.Parse(usage, nil, true, version, false, true)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
 
-	taskId := arguments["<taskId>"].(string)
-	port, err := strconv.Atoi(arguments["--port"].(string))
-	if err != nil {
-		log.Fatalf("Failed to convert port to integer")
+	// treat nil (arg not provided) the same as an empty string (arg provided
+	// but was empty string)
+	fetchArg := func(argName string) (argValue string) {
+		argValueInterface := arguments[argName]
+		if argValueInterface != nil {
+			argValue = argValueInterface.(string)
+		}
+		return argValue
 	}
 
-	relengapiToken := arguments["--relengapi-token"].(string)
+	taskId := fetchArg("<taskId>")
+	if taskId == "" {
+		log.Fatal("--task-id is required")
+	}
+
+	port, err := strconv.Atoi(fetchArg("--port"))
+	if err != nil {
+		log.Fatalf("Failed to convert port to integer (value supplied: %s)", arguments["--port"])
+	}
+
+	relengapiToken := fetchArg("--relengapi-token")
 	if relengapiToken == "" {
 		log.Fatal("--relengapi-token is required")
 	}
 
-	relengapiHost := arguments["--relengapi-host"].(string)
+	relengapiHost := fetchArg("--relengapi-host")
 
 	scopes, err := getTaskScopes(taskId)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	docopt "github.com/docopt/docopt-go"
 )
 
-var version = "RelengAPI proxy 1.0"
+var version = "RelengAPI proxy 2.0.0"
 var usage = `
 RelengAPI authentication proxy.
 
@@ -19,9 +19,9 @@ generated via an HTTP request to RelengAPI using the permanent token given via
 granted to a task.
 
   Usage:
-    ./proxy [options] -- <taskId>
-    ./proxy -h|--help
-    ./proxy --version
+    relengapi-proxy [options] -- <taskId>
+    relengapi-proxy -h|--help
+    relengapi-proxy --version
 
   Options:
     -h --help                  Show this help screen.


### PR DESCRIPTION
This is unfortunately a breaking change, since docopt assumes arguments beginning with `-` are options. This interpretation can only be changed if there is a position argument somewhere before it, which in our case there is not.

Attack strategies were:
1. switch away from using docopt - didn't like to do this as it has nice features, handles version and help, easy to read, and is what we use elsewhere
2. manipulate command line args (e.g. inject a `x` before taskId so it doesn't start with a `-` char) - didn't like to do this as it is a dirty hack, and also would need to handle -h, --help, --version cases too - gets quite ugly
3. adapt command line usage - chosen solution; disadvantage here is that we'll also need an update to docker worker - however, old docker worker + old relengapi-proxy will continue to work since new docker worker can depend on new relengapi-proxy. :+1: 

Another minor fix I slipped in here is that not specifying a command line argument is different to specifying an empty one. Previously it would crash if you didn't specify a required command line option at all - now it treats it the same as specifying an empty one (e.g. `--foo ''`).

Reminder: after we land this and publish new docker image, we should update docker-worker to use it.
