### PR TITLE
Bug 1218436 - added unit tests for command line parsing

### DIFF
--- a/argv_processing_test.go
+++ b/argv_processing_test.go
@@ -28,27 +28,34 @@ func TestUnknownParameter(t *testing.T) {
 	}
 }
 
-// using correct syntax should be ok
+// using correct syntax should be ok for an arbitrary taskId
 func TestValidCommand(t *testing.T) {
-	argv := []string{"--relengapi-token", "345", "--", "TRZquWniSYmYHlZn_-kLAw"}
-	_, err := parseProgramArgs(argv, false)
+	validCommand(t, "TRZquWniSYmYHlZn_-kLAw")
+}
+
+// specifying taskId starting with `-` works
+func TestLeadingHyphenInTaskId(t *testing.T) {
+	validCommand(t, "-RZquWniSYmYHlZn_-kLAw")
+}
+
+// utility function to check that a valid command is ok for a given taskId
+func validCommand(t *testing.T, taskId string) {
+	argv := []string{"--relengapi-token", "345", "--", taskId}
+	arguments, err := parseProgramArgs(argv, false)
 	if err != nil {
 		t.Fatalf("Expected args %s to be ok, but got error: %s", argv, err)
+	}
+	if arguments["<taskId>"] == nil {
+		t.Fatalf("No taskId returned")
+	}
+	if val := arguments["<taskId>"].(string); val != taskId {
+		t.Fatalf("Expected taskId to be %s but was %s", taskId, val)
 	}
 }
 
 // adding optional parameters works
 func TestOptionalParams(t *testing.T) {
 	argv := []string{"--relengapi-token", "345", "--port", "678", "--relengapi-host", "pretend-host", "--", "TRZquWniSYmYHlZn_-kLAw"}
-	_, err := parseProgramArgs(argv, false)
-	if err != nil {
-		t.Fatalf("Expected args %s to be ok, but got error: %s", argv, err)
-	}
-}
-
-// specifying taskId starting with `-` works
-func TestLeadingHyphenInTaskId(t *testing.T) {
-	argv := []string{"--relengapi-token", "345", "--", "-RZquWniSYmYHlZn_-kLAw"}
 	_, err := parseProgramArgs(argv, false)
 	if err != nil {
 		t.Fatalf("Expected args %s to be ok, but got error: %s", argv, err)

--- a/argv_processing_test.go
+++ b/argv_processing_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+)
+
+// at least one argument must be specified
+func TestCommandParser(t *testing.T) {
+	_, err := parseProgramArgs([]string{""}, false)
+	if err == nil {
+		t.Fatal("Expected error when passing no arguments")
+	}
+}
+
+// need -- before the given taskId
+func TestMinusMinusMissing(t *testing.T) {
+	_, err := parseProgramArgs([]string{"--relengapi-token", "345", "TRZquWniSYmYHlZn_-kLAw"}, false)
+	if err == nil {
+		t.Fatal("Expected error when not specifying --")
+	}
+}
+
+// adding unknown parameter causes error
+func TestUnknownParameter(t *testing.T) {
+	_, err := parseProgramArgs([]string{"--relengapi-token", "345", "--extra-parameter", "--", "TRZquWniSYmYHlZn_-kLAw"}, false)
+	if err == nil {
+		t.Fatal("Expected error when specifying extra parameter --extra-parameter")
+	}
+}
+
+// using correct syntax should be ok
+func TestValidCommand(t *testing.T) {
+	argv := []string{"--relengapi-token", "345", "--", "TRZquWniSYmYHlZn_-kLAw"}
+	_, err := parseProgramArgs(argv, false)
+	if err != nil {
+		t.Fatalf("Expected args %s to be ok, but got error: %s", argv, err)
+	}
+}
+
+// adding optional parameters works
+func TestOptionalParams(t *testing.T) {
+	argv := []string{"--relengapi-token", "345", "--port", "678", "--relengapi-host", "pretend-host", "--", "TRZquWniSYmYHlZn_-kLAw"}
+	_, err := parseProgramArgs(argv, false)
+	if err != nil {
+		t.Fatalf("Expected args %s to be ok, but got error: %s", argv, err)
+	}
+}
+
+// specifying taskId starting with `-` works
+func TestLeadingHyphenInTaskId(t *testing.T) {
+	argv := []string{"--relengapi-token", "345", "--", "-RZquWniSYmYHlZn_-kLAw"}
+	_, err := parseProgramArgs(argv, false)
+	if err != nil {
+		t.Fatalf("Expected args %s to be ok, but got error: %s", argv, err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -32,8 +32,7 @@ granted to a task.
 `
 
 func main() {
-
-	arguments, err := docopt.Parse(usage, nil, true, version, false, true)
+	arguments, err := parseProgramArgs(nil, true)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
@@ -82,4 +81,8 @@ func main() {
 		permissions:   relengapiPerms,
 		issuingToken:  relengapiToken,
 	}.runForever()
+}
+
+func parseProgramArgs(argv []string, exit bool) (map[string]interface{}, error) {
+	return docopt.Parse(usage, argv, true, version, false, exit)
 }


### PR DESCRIPTION
In #4 I introduced code to alter the command line parsing of relengapi-proxy. At the time the unit tests were broken #5 so I didn't write any tests for the new code.

Since then, #5 has been resolved (many thanks to @djmitche!) so now I'm adding tests for my code changes in #4 .

Also thanks to dustin, we now also have travis running these tests. \o/

@gregarndt FYI re: https://github.com/taskcluster/docker-worker/pull/176
