### PR TITLE
Adapted to work with upstream changes in taskcluster-client-go

### DIFF
--- a/taskcluster.go
+++ b/taskcluster.go
@@ -12,7 +12,7 @@ func getTaskScopes(taskId string) ([]string, error) {
 	)
 	q.Authenticate = false
 
-	task, _, err := q.Task(taskId)
+	task, err := q.Task(taskId)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Upstream removed `CallSummary` and made some lint fixes.
