### PR TITLE
Bug 1285197 - fix go get warning for taskcluster-client-go

### DIFF
--- a/taskcluster.go
+++ b/taskcluster.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	queue "github.com/taskcluster/taskcluster-client-go/queue"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
+	"github.com/taskcluster/taskcluster-client-go/queue"
 )
 
 func getTaskScopes(taskId string) ([]string, error) {


### PR DESCRIPTION
This depends on taskcluster/taskcluster-client-go#15 so I would expect travis to fail for this PR until that has landed. When the other PR lands, you should be able to rerun the travis jobs on this PR.
