### PR TITLE
redirect tooltool/treestatus traffic to mozilla-releng.net

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"time"
+	"strings"
 )
 
 type RelengapiProxy struct {
@@ -53,10 +54,30 @@ func (rp RelengapiProxy) runForever() {
 	// httputil's ReverseProxy is not specifically "reverse", and it will
 	// do fine here.  The director transforms outgoing requests.
 	director := func(req *http.Request) {
-		// point toward the upstream server
-		req.URL.Scheme = "https"
-		req.URL.Host = rp.relengapiHost
-		req.Host = rp.relengapiHost
+        // redirect tooltool traffic to tooltool.mozilla-releng.net
+        if strings.HasPrefix(req.URL.Path, "/tooltool") {
+            req.URL.Scheme = "https"
+            req.URL.Path = strings.TrimPrefix(req.URL.Path, "/tooltool")
+            req.URL.RawPath = ""
+            req.URL.Host = "tooltool.mozilla-releng.net"
+            req.Host = "tooltool.mozilla-releng.net"
+        // redirect treestatus traffic to treestatus.mozilla-releng.net
+        } else if strings.HasPrefix(req.URL.Path, "/treestatus") {
+            req.URL.Scheme = "https"
+            req.URL.Path = strings.TrimPrefix(req.URL.Path, "/treestatus")
+            req.URL.RawPath = ""
+            req.URL.Host = "treestatus.mozilla-releng.net"
+            req.Host = "treestatus.mozilla-releng.net"
+        // other services then tooltool and treestatus/tooltool are still using
+        // old url. once all services are migrated to new url then we will clean
+        // up this and make this function more generic
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1393648
+        } else {
+            // point toward the upstream server
+            req.URL.Scheme = "https"
+            req.URL.Host = rp.relengapiHost
+            req.Host = rp.relengapiHost
+        }
 		// Add the token
 		tok, err := rp.getToken()
 		if err != nil {
@@ -69,6 +90,7 @@ func (rp RelengapiProxy) runForever() {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tok))
 		// log
 		log.Println(req.Method, req.URL)
+
 	}
 	proxy := &httputil.ReverseProxy{Director: director}
 


### PR DESCRIPTION
other services then tooltool and treestatus are still using old url.
once all services are migrated to new url then we will clean up and make
this part more generic

/cc @djmitche @petemoore 