### PR TITLE
Bug 1546384 - Hard code rootURL as https://taskcluster.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # RelEngAPI Proxy
 
 This is the proxy server which is used in the docker-worker which allows
-individual tasks to talk to various taskcluster services (auth, queue,
-scheduler) without hardcoding credentials into the containers themselves.
+individual tasks to talk to [Releng
+API](https://github.com/mozilla/build-relengapi) without hardcoding credentials
+into the containers themselves.
 
 This works by creating a temporary RelengAPI access token bearing the
 permissions specified for the task.  Permissions are specified as scopes, with
@@ -13,6 +14,12 @@ cannot be used to get all relengapi permissions.
 
 The temporary token is requested using a permanent token known only to the
 proxy, given on the command line with `--relengapi-token`.
+
+__Note, relengapi-proxy can currently only run on https://taskcluster.net !!__
+
+If other taskcluster deployment environments need to be supported, the
+hardcoded reference to this `rootURL` should be removed from the code, and the
+rootURL should be provided as an additional required command line parameter.
 
 ## Examples
 

--- a/taskcluster.go
+++ b/taskcluster.go
@@ -4,7 +4,12 @@ import "github.com/taskcluster/taskcluster-client-go/tcqueue"
 
 func getTaskScopes(taskId string) ([]string, error) {
 	// We do not need auth for this operation
-	q := tcqueue.New(nil)
+	//
+	// NOTE: currently, the only supported rootURL is https://taskcluster.net !!
+	//
+	// If this needs to change, remove this hardcoded reference, and make it a
+	// (required) command line parameter to be passed to the proxy on start up.
+	q := tcqueue.New(nil, "https://taskcluster.net")
 	task, err := q.Task(taskId)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
See [bug 1546384](https://bugzil.la/1546384) for context.

My assumption here is that we'll never want to support root URLs for `relengapi-proxy` other than https://taskcluster.net - but I may be mistaken!

So I just did the lazy thing, but if this isn't the case, happy to update the PR to add `rootURL` as a config setting, make a new release, and then update docker-worker to use it. If that can be avoided, of course, that is preferred! :-D